### PR TITLE
 Modified ProfileServlet to show messages on profile page

### DIFF
--- a/src/main/java/codeu/controller/ChatServlet.java
+++ b/src/main/java/codeu/controller/ChatServlet.java
@@ -91,6 +91,7 @@ public class ChatServlet extends BaseServlet {
       response.sendRedirect("/conversations");
       return;
     }
+    user.addConversationIds(conversation.getId());
 
     String messageContent = request.getParameter("message");
 

--- a/src/main/java/codeu/controller/ProfileServlet.java
+++ b/src/main/java/codeu/controller/ProfileServlet.java
@@ -5,6 +5,7 @@ import codeu.model.data.Message;
 import codeu.model.data.User;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import javax.servlet.ServletException;
@@ -35,8 +36,18 @@ public class ProfileServlet extends BaseServlet {
       request.getRequestDispatcher("/WEB-INF/view/profile.jsp").forward(request, response);
       return;
     }
+    List<Message> authorMessages = new ArrayList<>();
+    for (UUID conversationId : user.getConversationIds()){
+      List<Message> messages = messageStore.getMessagesInConversation(conversationId);
+      for(Message message: messages){
+        if(message.getAuthorId().equals(user.getId())){
+          authorMessages.add(message);
+        }
+      }
+    }
 
     request.setAttribute("view_user", user);
+    request.setAttribute("messages", authorMessages);
     request.getRequestDispatcher("/WEB-INF/view/profile.jsp").forward(request, response);
   }
 

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -4,6 +4,7 @@ import codeu.model.data.User;
 import codeu.model.store.basic.UserStore;
 import java.io.IOException;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.UUID;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServlet;
@@ -62,7 +63,7 @@ public class RegisterServlet extends HttpServlet {
       return;
     }
 
-    User user = new User(UUID.randomUUID(), username, passwordHash, Instant.now());
+    User user = new User(UUID.randomUUID(), username, passwordHash, Instant.now(), new ArrayList<>());
     userStore.addUser(user);
 
     response.sendRedirect("/login");

--- a/src/main/java/codeu/controller/ServerStartupListener.java
+++ b/src/main/java/codeu/controller/ServerStartupListener.java
@@ -31,6 +31,10 @@ public class ServerStartupListener implements ServletContextListener {
       List<Message> messages = PersistentStorageAgent.getInstance().loadMessages();
       MessageStore.getInstance().setMessages(messages);
 
+      for(Message message:messages){
+        User author = UserStore.getInstance().getUser(message.getAuthorId());
+        author.addConversationIds(message.getConversationId());
+      }
     } catch (PersistentDataStoreException e) {
       System.err.println("Server didn't start correctly. An error occurred during Datastore load!");
       System.err.println("This is usually caused by loading data that's in an invalid format.");

--- a/src/main/java/codeu/model/data/User.java
+++ b/src/main/java/codeu/model/data/User.java
@@ -15,6 +15,7 @@
 package codeu.model.data;
 import java.time.Instant;
 import java.util.UUID;
+import java.util.List;
 import org.mindrot.jbcrypt.*;
 
 /** Class representing a registered user. */
@@ -24,6 +25,7 @@ public class User {
   private final String hashedPassword;
   private final Instant creation;
   private boolean isAdmin;
+  private List<UUID> conversationIds;
 
   /**
    * Constructs a new User.
@@ -32,13 +34,16 @@ public class User {
    * @param name the username of this User
    * @param hashedPassword the users password
    * @param creation the creation time of this User
+   * @param conversationIds the conversation titles that this User is in
    */
-  public User(UUID id, String name, String hashedPassword, Instant creation) {
+  public User(UUID id, String name, String hashedPassword, Instant creation,
+              List<UUID> conversationIds) {
     this.id = id;
     this.name = name;
     this.creation = creation;
     this.hashedPassword = hashedPassword;
     isAdmin = false;
+    this.conversationIds = conversationIds;
   }
 
   /** Returns the ID of this User. */
@@ -59,6 +64,19 @@ public class User {
   /** Returns the creation time of this User. */
   public Instant getCreationTime() {
     return creation;
+  }
+
+  /** Returns the conversation titles of this User. */
+  public List<UUID> getConversationIds() {
+    return conversationIds;
+  }
+
+  public void addConversationIds(UUID id){
+    for(UUID conversationId:conversationIds){
+      if(conversationId.equals(id))  return;
+    }
+    conversationIds.add(id);
+    //PersistentStorageAgent.getInstance().writeThrough(user);
   }
 
   /** Sets the user as an admin. */

--- a/src/main/java/codeu/model/store/basic/DefaultDataStore.java
+++ b/src/main/java/codeu/model/store/basic/DefaultDataStore.java
@@ -99,7 +99,8 @@ public class DefaultDataStore {
     Collections.shuffle(randomUsernames);
 
     for (int i = 0; i < DEFAULT_USER_COUNT; i++) {
-      User user = new User(UUID.randomUUID(), randomUsernames.get(i), BCrypt.hashpw("password", BCrypt.gensalt()), Instant.now());
+      User user = new User(UUID.randomUUID(), randomUsernames.get(i),
+              BCrypt.hashpw("password", BCrypt.gensalt()), Instant.now(), new ArrayList<>());
       PersistentStorageAgent.getInstance().writeThrough(user);
       users.add(user);
     }
@@ -121,7 +122,7 @@ public class DefaultDataStore {
       Conversation conversation = getRandomElement(conversations);
       User author = getRandomElement(users);
       String content = getRandomMessageContent();
-
+      author.addConversationIds(conversation.getId());
       Message message =
           new Message(
               UUID.randomUUID(), conversation.getId(), author.getId(), content, Instant.now());

--- a/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
+++ b/src/main/java/codeu/model/store/persistence/PersistentDataStore.java
@@ -66,7 +66,7 @@ public class PersistentDataStore {
         String userName = (String)entity.getProperty("username");
         String password = (String)entity.getProperty("password");
         Instant creationTime = Instant.parse((String)entity.getProperty("creation_time"));
-        User user = new User(uuid, userName, password, creationTime);
+        User user = new User(uuid, userName, password, creationTime, new ArrayList<>());
         users.add(user);
       } catch (Exception e) {
         // In a production environment, errors should be very rare. Errors which may

--- a/src/main/webapp/WEB-INF/view/profile.jsp
+++ b/src/main/webapp/WEB-INF/view/profile.jsp
@@ -14,9 +14,11 @@
   limitations under the License.
 --%>
 <%@ page import="java.util.List" %>
+<%@ page import="java.time.format.DateTimeFormatter" %>
+<%@ page import="java.time.ZoneId" %>
+<%@ page import="java.time.Instant" %>
 <%@ page import="codeu.model.data.User" %>
 <%@ page import="codeu.model.data.Message" %>
-<%@ page import="codeu.model.store.basic.UserStore" %>
 
 <% User user = (User) request.getAttribute("view_user"); %>
 <!DOCTYPE html>
@@ -65,9 +67,22 @@
     <hr/>
     <h2><%= user.getName() %>'s Sent Messages</h2>
 
-    <hr/>
     <div id="chat">
+        <ul>
+            <%
+                List<Message> messages = (List<Message>) request.getAttribute("messages");
+                for (Message message : messages) {
+                    Instant time = message.getCreationTime();
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("EEE yyyy-MM-dd HH:mm:ss")
+                            .withZone(ZoneId.systemDefault());
 
+                    String timeString = formatter.format(time);
+            %>
+            <li><strong><%= timeString %>:</strong> <%= message.getContent() %></li>
+            <%
+                }
+            %>
+        </ul>
     </div>
     <hr/>
     <% } %>

--- a/src/test/java/codeu/controller/ChatServletTest.java
+++ b/src/test/java/codeu/controller/ChatServletTest.java
@@ -135,7 +135,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now(),
+            new ArrayList<>());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
@@ -152,11 +153,13 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now(),
+            new ArrayList<>());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
+    UUID conversationId = UUID.randomUUID();
     Conversation fakeConversation =
-        new Conversation(UUID.randomUUID(), UUID.randomUUID(), "test_conversation", Instant.now());
+        new Conversation(conversationId, UUID.randomUUID(), "test_conversation", Instant.now());
     Mockito.when(mockConversationStore.getConversationWithTitle("test_conversation"))
         .thenReturn(fakeConversation);
 
@@ -176,7 +179,8 @@ public class ChatServletTest {
     Mockito.when(mockRequest.getRequestURI()).thenReturn("/chat/test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_passord", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_passord", Instant.now(),
+            new ArrayList<>());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Conversation fakeConversation =

--- a/src/test/java/codeu/controller/ConversationServletTest.java
+++ b/src/test/java/codeu/controller/ConversationServletTest.java
@@ -105,7 +105,8 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("bad !@#$% name");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now(),
+            new ArrayList<>());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     conversationServlet.doPost(mockRequest, mockResponse);
@@ -121,7 +122,8 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now(),
+            new ArrayList<>());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(true);
@@ -138,7 +140,8 @@ public class ConversationServletTest {
     Mockito.when(mockRequest.getParameter("conversationTitle")).thenReturn("test_conversation");
     Mockito.when(mockSession.getAttribute("user")).thenReturn("test_username");
 
-    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    User fakeUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now(),
+            new ArrayList<>());
     Mockito.when(mockUserStore.getUser("test_username")).thenReturn(fakeUser);
 
     Mockito.when(mockConversationStore.isTitleTaken("test_conversation")).thenReturn(false);

--- a/src/test/java/codeu/controller/ProfileServletTest.java
+++ b/src/test/java/codeu/controller/ProfileServletTest.java
@@ -56,7 +56,7 @@ public class ProfileServletTest {
     Mockito.when(mockRequest.getSession()).thenReturn(mockSession);
 
     mockResponse = Mockito.mock(HttpServletResponse.class);
-    mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
+     mockRequestDispatcher = Mockito.mock(RequestDispatcher.class);
     Mockito.when(mockRequest.getRequestDispatcher("/WEB-INF/view/profile.jsp"))
             .thenReturn(mockRequestDispatcher);
 

--- a/src/test/java/codeu/model/data/UserTest.java
+++ b/src/test/java/codeu/model/data/UserTest.java
@@ -15,6 +15,8 @@
 package codeu.model.data;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import org.junit.Assert;
 import org.junit.Test;
@@ -27,12 +29,13 @@ public class UserTest {
     String name = "test_username";
     Instant creation = Instant.now();
     String password = "password";
-
-    User user = new User(id, name, password, creation);
+    List<UUID> conversationIds = new ArrayList<>();
+    User user = new User(id, name, password, creation, conversationIds);
 
     Assert.assertEquals(id, user.getId());
     Assert.assertEquals(name, user.getName());
     Assert.assertEquals(password, user.getPassword());
     Assert.assertEquals(creation, user.getCreationTime());
+    Assert.assertEquals(conversationIds, user.getConversationIds());
   }
 }

--- a/src/test/java/codeu/model/store/basic/UserStoreTest.java
+++ b/src/test/java/codeu/model/store/basic/UserStoreTest.java
@@ -17,11 +17,14 @@ public class UserStoreTest {
   private PersistentStorageAgent mockPersistentStorageAgent;
 
   private final User USER_ONE =
-      new User(UUID.randomUUID(), "test_username_one", "password_one", Instant.ofEpochMilli(1000));
+      new User(UUID.randomUUID(), "test_username_one", "password_one", Instant.ofEpochMilli(1000),
+              new ArrayList<>());
   private final User USER_TWO =
-      new User(UUID.randomUUID(), "test_username_two", "password_two", Instant.ofEpochMilli(2000));
+      new User(UUID.randomUUID(), "test_username_two", "password_two", Instant.ofEpochMilli(2000),
+              new ArrayList<>());
   private final User USER_THREE =
-      new User(UUID.randomUUID(), "test_username_three", "password_three", Instant.ofEpochMilli(3000));
+      new User(UUID.randomUUID(), "test_username_three", "password_three", Instant.ofEpochMilli(3000),
+              new ArrayList<>());
 
   @Before
   public void setup() {
@@ -65,7 +68,8 @@ public class UserStoreTest {
 
   @Test
   public void testAddUser() {
-    User inputUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    User inputUser = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now(),
+            new ArrayList<>());
 
     userStore.addUser(inputUser);
     User resultUser = userStore.getUser("test_username");
@@ -88,6 +92,7 @@ public class UserStoreTest {
     Assert.assertEquals(expectedUser.getId(), actualUser.getId());
     Assert.assertEquals(expectedUser.getName(), actualUser.getName());
     Assert.assertEquals(expectedUser.getCreationTime(), actualUser.getCreationTime());
-    Assert.assertEquals(expectedUser.getPassword(), actualUser.getPassword());  
+    Assert.assertEquals(expectedUser.getPassword(), actualUser.getPassword());
+    Assert.assertEquals(expectedUser.getConversationIds(), actualUser.getConversationIds());
   }
 }

--- a/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentDataStoreTest.java
@@ -6,6 +6,7 @@ import codeu.model.data.User;
 import com.google.appengine.tools.development.testing.LocalDatastoreServiceTestConfig;
 import com.google.appengine.tools.development.testing.LocalServiceTestHelper;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 import org.junit.After;
@@ -42,13 +43,15 @@ public class PersistentDataStoreTest {
     String nameOne = "test_username_one";
     String passwordOne = "passwordOne";
     Instant creationOne = Instant.ofEpochMilli(1000);
-    User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne);
+    List<UUID> conversationIdsOne = new ArrayList<>();
+    User inputUserOne = new User(idOne, nameOne, passwordOne, creationOne, conversationIdsOne);
 
     UUID idTwo = UUID.randomUUID();
     String nameTwo = "test_username_two";
     String passwordTwo = "passwordTwo";
     Instant creationTwo = Instant.ofEpochMilli(2000);
-    User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, creationTwo);
+    List<UUID> conversationIdsTwo = new ArrayList<>();
+    User inputUserTwo = new User(idTwo, nameTwo, passwordTwo, creationTwo, conversationIdsTwo);
 
     // save
     persistentDataStore.writeThrough(inputUserOne);
@@ -63,12 +66,14 @@ public class PersistentDataStoreTest {
     Assert.assertEquals(nameOne, resultUserOne.getName());
     Assert.assertEquals(creationOne, resultUserOne.getCreationTime());
     Assert.assertEquals(passwordOne, resultUserOne.getPassword());
+    Assert.assertEquals(conversationIdsOne, resultUserOne.getConversationIds());
 
     User resultUserTwo = resultUsers.get(1);
     Assert.assertEquals(idTwo, resultUserTwo.getId());
     Assert.assertEquals(nameTwo, resultUserTwo.getName());
     Assert.assertEquals(creationTwo, resultUserTwo.getCreationTime());
     Assert.assertEquals(passwordTwo, resultUserTwo.getPassword());
+    Assert.assertEquals(conversationIdsTwo, resultUserTwo.getConversationIds());
   }
 
   @Test

--- a/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
+++ b/src/test/java/codeu/model/store/persistence/PersistentStorageAgentTest.java
@@ -4,6 +4,7 @@ import codeu.model.data.Conversation;
 import codeu.model.data.Message;
 import codeu.model.data.User;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.UUID;
 import org.junit.Before;
 import org.junit.Test;
@@ -46,7 +47,8 @@ public class PersistentStorageAgentTest {
 
   @Test
   public void testWriteThroughUser() {
-    User user = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now());
+    User user = new User(UUID.randomUUID(), "test_username", "test_password", Instant.now(),
+            new ArrayList<>());
     persistentStorageAgent.writeThrough(user);
     Mockito.verify(mockPersistentDataStore).writeThrough(user);
   }


### PR DESCRIPTION
Added conversationIds field to User class to save the conversation ids that the user is in.
Modified ProfileServlet and profile.jsp to handle individual messages shown on profile page.
Current Algorithm: For each conversationId, get a list of messages from messageStore and filter those written by the user.
When a user tries to add a message to a conversation where he never sent messages, add the corresponding conversationId to user.
Modified ServerStartupListener to add previous conversationIds to users in the beginning.