### PR TITLE
Default Admin and View

### DIFF
--- a/src/main/java/codeu/controller/AdminServlet.java
+++ b/src/main/java/codeu/controller/AdminServlet.java
@@ -22,6 +22,12 @@ import javax.servlet.http.HttpServletResponse;
 public class AdminServlet extends BaseServlet {
   @Override
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException, ServletException {
+    //Makes sure person accessing admin page is an admin
+    if (request.getSession().getAttribute("admin") == null){
+      response.sendRedirect("/");
+      return;
+    }
+    
     request.setAttribute("numUsers", numUsers());
     request.setAttribute("numConvos", numConvos());
     request.setAttribute("numMessages", numMessages());

--- a/src/main/java/codeu/controller/LoginServlet.java
+++ b/src/main/java/codeu/controller/LoginServlet.java
@@ -74,7 +74,7 @@ public class LoginServlet extends HttpServlet {
       User user = userStore.getUser(username);
       if(BCrypt.checkpw(password, user.getPassword())) {
         if (user.getIsAdmin()){
-          request.getSession().setAttribute("admin",true);
+          request.getSession().setAttribute("admin", true);
         }
         request.getSession().setAttribute("user", username);
         response.sendRedirect("/conversations");

--- a/src/main/java/codeu/controller/LoginServlet.java
+++ b/src/main/java/codeu/controller/LoginServlet.java
@@ -73,6 +73,9 @@ public class LoginServlet extends HttpServlet {
     if (userStore.isUserRegistered(username)) {
       User user = userStore.getUser(username);
       if(BCrypt.checkpw(password, user.getPassword())) {
+        if (user.getIsAdmin()){
+          request.getSession().setAttribute("admin",true);
+        }
         request.getSession().setAttribute("user", username);
         response.sendRedirect("/conversations");
       }

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -67,6 +67,15 @@ public class RegisterServlet extends HttpServlet {
     User user = new User(UUID.randomUUID(), username, passwordHash, Instant.now(), new ArrayList<>(), about);
     userStore.addUser(user);
 
+    //Checks if someone registered the default admin account
+    //Username: admin
+    //Password: admin
+    if (username.equals("admin")){
+      if (password.equals("admin")){
+        user.setAsAdmin();
+      }
+    }
+
     response.sendRedirect("/login");
   }
 }

--- a/src/main/java/codeu/controller/RegisterServlet.java
+++ b/src/main/java/codeu/controller/RegisterServlet.java
@@ -64,8 +64,14 @@ public class RegisterServlet extends HttpServlet {
       return;
     }
 
+    //Doesn't let someone register with default admin username and different password
+    if (username.equals("admin") && !password.equals("admin")){
+      request.setAttribute("error", "That username is for admin only.");
+      request.getRequestDispatcher("/WEB-INF/view/register.jsp").forward(request, response);
+      return;
+    }
+
     User user = new User(UUID.randomUUID(), username, passwordHash, Instant.now(), new ArrayList<>(), about);
-    userStore.addUser(user);
 
     //Checks if someone registered the default admin account
     //Username: admin
@@ -76,6 +82,7 @@ public class RegisterServlet extends HttpServlet {
       }
     }
 
+    userStore.addUser(user);
     response.sendRedirect("/login");
   }
 }

--- a/src/main/webapp/index.jsp
+++ b/src/main/webapp/index.jsp
@@ -32,7 +32,9 @@
       <a href="/register">Register</a>
     <% } %>
     <a href="/about.jsp">About</a>
-    <a href="/testdata">Load Test Data</a>
+    <% if(request.getSession().getAttribute("admin") != null){ %>
+      <a href="/admin">Admin</a>
+    <% } %>
   </nav>
 
   <div id="container">


### PR DESCRIPTION
Added a default admin user:

Username: admin
Password: admin

This is for testing purposes and because we don't currently have a way for users to become admin. I also removed the test data tab from the home page because loading data is now an admin only feature. I added the admin tab to replace that but it only shows up if the current user is an admin. I also made a check to make sure that if a non-admin reaches the admin page they will be redirected to home.

Fixes:
Issue #54 
Issue #55 
Issue #56 